### PR TITLE
Beispiel von "consultation" falsch

### DIFF
--- a/dokument/master/chapter_8090.md
+++ b/dokument/master/chapter_8090.md
@@ -60,10 +60,7 @@ Zunächst ein Kontext:
     "number": "10.1",
     "name": "Satzungsänderung für Ausschreibungen",
     "public": true,
-    "consultation": [
-        "beispielris:consultation/1034",
-        "beispielris:consultation/1235"
-    ],
+    "consultation": "beispielris:consultation/1034",
     "result": "beispielris:vocab/decided_modified",
     "resolution": "Der Beschluss weicht wie folgt vom Antrag ab: ...",
     "absentParticipant": "beispielris:person/75",


### PR DESCRIPTION
Bei einer Kardinalität von 0 bis 1 können sich dort nicht 2 Werte stehen.
