### PR TITLE
ZWINGEND heißt Kardinalität 1

### DIFF
--- a/dokument/master/chapter_8100.md
+++ b/dokument/master/chapter_8100.md
@@ -73,7 +73,7 @@ Kennungen der Drucksachen zum Einsatz.
 `publishedDate`
 :   Veröffentlichungsdatum der Drucksache.
     Typ: `xsd:dateTime` oder `xsd:date`.
-    Kardinalität: 0 bis 1.
+    Kardinalität: 1.
     ZWINGEND.
 
 `paperType`


### PR DESCRIPTION
Wenn eine Eigenschaft zwingen ist, dann kann sie nicht die Kardinalität 0 haben.