### PR TITLE
editorconfig hinzufügen

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_size = 4
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+


### PR DESCRIPTION
[editorconfig](http://editorconfig.org/) bietet die Möglichkeit, IDE's und editoren automatisch auf die Formatierungsrichtlinien von Projekten einzustellen. Das verhindert z.B. das vermischen von tabs und Leerzeichen.