### PR TITLE
Readme überarbeitet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,29 @@
 
 ![OParl Wortmarke](https://raw.githubusercontent.com/OParl/brand/master/wortmarke/oparl-wortmarke-rgb-m.png)
 
-In diesem Repository wird die Spezifikation zum [OParl](http://oparl.org/)-Standard erarbeitet.
+In diesem Repository wird die Spezifikation zum [OParl](https://oparl.org/)-Standard erarbeitet.
 
-OParl ist eine Initiative für die Offenheit parlamentarischer Informationssysteme. Der
-OParl-Standard dient der Definition einer einheitlichen Schnittstelle zum Abruf von
-öffenltichen Informationen aus Ratsinformationssystemen. Mehr über OParl:
+Der OParl-Standard dient der Definition einer einheitlichen Schnittstelle zum Abruf von
+maschienlesbaren Informationen aus Ratsinformationssystemen. Mehr über OParl:
 
-  [http://oparl.org/](http://oparl.org/)
+  [oparl.org/](https://oparl.org/)
 
 
-Original: Editieren, Änderungen nachvollziehen
-----------------------------------------------
+## Änderungen an OParl vornehmen
 
-Wenn Du Dich für die Quellen des Dokuments sowie für das Nachvollziehen von Änderungen an den Quellen interessierst, findest Du dies im Ordner:
+OParl wird hauptsächlich auf GitHub entwickelt. Hilfe im Umgang mit GitHub findest du [hier](https://help.github.com/). Änderungsvorschläge können über Pull Requests eingebracht werden.
 
-    src
+Die Dateien, aus denen die Spezifikation erstellt wird, sind auf mehrere Ordner aufgeteilt:
+ - `src/`:  Enthält den gesammten Fließtext als [Markdown](https://help.github.com/articles/markdown-basics/)-Dateien. 
+ - `schema/`: Enthält das Datenmodell, d.h. den Aufbau der von OParl genutzten json-Objekte, als json-Dateien in einem eigenen Format.
+ - `examples/`: Die im Text eingebundenen Beispiele
+ - `scripts/`: Enthält hauptsächlich die python-skripte, die die json-Dateien in Markdown umwandeln
 
-Die Quelldateien sind reine Textdateien (Zeichensatz: UTF-8) mit [Markdown](http://daringfireball.net/projects/markdown/)-Formatierung (Dateiendung: .md).
+Durch den Befehl `make` kann aus den Quelldateien die Spezifikation erstellt werden. Dazu müssen pandoc und latex installiert sein. Die fertigen Dokumente finden sich dann im Ornder `out`.
 
-Änderungswünsche am Dokument können in Form von Pull Requests beigesteuert werden. Dazu erzeugst Du zunächst einen Fork dieses Repositories. Dann committest Du Änderungen an Deinem Fork. Danach kannst Du am einzelnen Commit die Funktion "Send Pull Request" auslösen. Mehr dazu in der [Github-Hilfe](https://help.github.com/articles/using-pull-requests).
+## Die Spezifikation in verschiedenen Formaten
 
-**Übrigens:** [prose.io](http://prose.io/) ist ein fantastischer Web-basierter Editor, mit dem Du die Markdown-Dateien in Deinem eigenen Repository spielend im Browser bearbeiten kannst.
-
-Änderungsinfos können übrigens in Form eines [Atom Feeds](https://github.com/OParl/specs/commits/master.atom) abonniert werden.
-
-Derivate: Bequemes Lesen auf verschiedenen Geräten
---------------------------------------------------
-
-Es stehen Versionen des Dokuments in vielen Formaten zur Verfügung:
+Es stehen Versionen des Dokuments in verschiedenen Formaten zur Verfügung:
 
 * [PDF](http://spec.oparl.org/downloads/latest.pdf)
 * [OpenOffice/LibreOffice](http://spec.oparl.org/downloads/latest.odt)
@@ -38,5 +33,3 @@ Es stehen Versionen des Dokuments in vielen Formaten zur Verfügung:
 * [EPub](http://spec.oparl.org/downloads/latest.epub)
 * [Nur Text](http://spec.oparl.org/downloads/latest.txt)
 
-Die Derivate werden unter anderem mit der Hilfe von [Pandoc](http://johnmacfarlane.net/pandoc/)
-erzeugt. Der gesamte Prozess wird durch das `Makefile` automatisiert.


### PR DESCRIPTION
 - Wir haben https für oparl.org
 - Eine Kurzanleitung für GitHub gehört nicht in ein Readme
 - Ordnerstruktur hinzugefügt