### PR TITLE
paging: ensure that list-types are not arbitrary

### DIFF
--- a/src/2-05-objektlisten-und-paginierung.md
+++ b/src/2-05-objektlisten-und-paginierung.md
@@ -4,7 +4,9 @@ Oft wird für ein Attribut kein Wert ausgegeben, sondern ein anderes Objekt oder
 eine Liste von Objekten. Dabei kann eine Referenz auf das Objekt bzw. die
 Objektliste angegeben werden, oder das Objekt bzw. die Objektlist wird intern
 ausgegeben. Beide Verfahren sollen im Folgenden erklärt werden.
-
+Zu beachten ist, dass für jedes Listenattribut festgelegt ist, welches dieser
+Verfahren jeweils zu verwenden ist. Diese Information ist den Schemadefinitionen
+zu entnehmen.
 
 ### Referenzierung von Objekten via URL
 

--- a/src/2-05-objektlisten-und-paginierung.md
+++ b/src/2-05-objektlisten-und-paginierung.md
@@ -5,8 +5,8 @@ eine Liste von Objekten. Dabei kann eine Referenz auf das Objekt bzw. die
 Objektliste angegeben werden, oder das Objekt bzw. die Objektlist wird intern
 ausgegeben. Beide Verfahren sollen im Folgenden erklärt werden.
 Zu beachten ist, dass für jedes Listenattribut festgelegt ist, welches dieser
-Verfahren jeweils zu verwenden ist. Diese Information ist den Schemadefinitionen
-zu entnehmen.
+Verfahren jeweils zu verwenden ist. Diese Information ist den
+[Schemadefinitionen](#schema) zu entnehmen.
 
 ### Referenzierung von Objekten via URL
 


### PR DESCRIPTION
apparently it wasn't sufficiently clarified that each list attribute
has a fixed type of list that it has to use. people misread that for
"i can implement whatever list-type i want"