### PR TITLE
Constraint-Ergänzung zu Person.locationObject

### DIFF
--- a/schema/Person.json
+++ b/schema/Person.json
@@ -77,7 +77,7 @@
             "format": "url"
         },
         "locationObject": {
-            "description": "Referenz der Kontakt-Anschrift der Person. Dies sollte die eigentlich Ausgabeform von `location` in OParl 1.0 werden, was jedoch auf Grund eines Fehler nicht geschehen ist. s. https://github.com/OParl/spec/issues/373. Neu in OParl 1.1",
+            "description": "Kontakt-Anschrift der Person. Wenn diese Eigenschaft ausgegeben wird, dann **muss** auch die Eigenschaft `location` ausgegeben werden und auf das gleiche Location-Objekt verweisen. Dies sollte die eigentliche Ausgabeform von `location` in OParl 1.0 werden, was jedoch auf Grund eines Fehlers nicht geschehen ist. s. https://github.com/OParl/spec/issues/373. Neu in OParl 1.1",
             "type": "object",
             "schema": "Location.json"
         },


### PR DESCRIPTION
Klargestellt, dass Person.locationObject nur als Ergänzung zu Person.location verwendet werden darf (da sonst alte Clients andere Daten sehen würden).