### PR TITLE
Add `mainOrganization` to `oparl:Body`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.sh linguist-vendored
 *.json linguist-vendored
 Makefile linguist-vendored
+Dockerfile linguist-vendored
 *.tex linguist-vendored
 *.css linguist-vendored
 *.html linguist-vendored

--- a/schema/Body.json
+++ b/schema/Body.json
@@ -198,6 +198,14 @@
             "type": "object",
             "schema": "Location.json"
         },
+        "mainOrganization": {
+            "description": "{{ Body.properties.mainOrganization.description }}",
+            "type": "string",
+            "format": "url",
+            "schema": "Organization",
+            "references": "Organization",
+            "cardinality": "1:1"
+        },
         "keyword": {
             "type": "array",
             "items": {

--- a/schema/strings.yml
+++ b/schema/strings.yml
@@ -138,6 +138,7 @@ de:
   Body.properties.legislativeTerm.description: "[Objektliste](#objektlisten) mit den Wahlperioden der Körperschaft."
   Body.properties.classification.description: Art der Körperschaft.
   Body.properties.location.description: Ort, an dem die Körperschaft beheimatet ist.
+  Body.properties.mainOrganization.description: Das zentrale Gremium einer Körperschaft. Bei einer Stadt wäre das z.B. die Vollversammlung des Stadtrats, beim Bundestag das Plenum.
   Consultation.description: |
     Der Objekttyp `oparl:Consultation` dient dazu, die Beratung einer Drucksache ([`oparl:Paper`](#oparl_paper)) in einer Sitzung abzubilden. Dabei ist es nicht entscheidend, ob diese Beratung in der Vergangenheit stattgefunden hat oder diese für die Zukunft geplant ist.
     Die Gesamtheit aller Objekte des Typs `oparl:Consultation` zu einer bestimmten Drucksache bildet das ab, was in der Praxis als "Beratungsfolge" der Drucksache bezeichnet wird.

--- a/src/4-02-oparl-next.md
+++ b/src/4-02-oparl-next.md
@@ -1,3 +1,4 @@
 ## OParl Next {#oparl-next}
 
  * `Person` hat ein Feld `image` erhalten.
+ * `Body` kann `mainOrganization` angeben.


### PR DESCRIPTION
In jeder mir bekannten Körperschaft gibt es ein Hauptgremium. In den meisten Städten ist das der Stadtrat, bei den Münchner Bezirksausschüssen ist es das Vollgremium und beim Bundestag wäre es das Plenum. Mit `mainOrganization` kann diese Eigenschaft aus `oparl:Body` verlinkt werden. Das ist besonders dadurch relevant, dass die Mitglieder dieses Gremiums i.d.R. die gewählten Vertreter der jeweiligen Verwaltungsebene sind.