### PR TITLE
Add passage for depublicized objects

### DIFF
--- a/src/2-08-geloeschte-objekte.md
+++ b/src/2-08-geloeschte-objekte.md
@@ -27,7 +27,6 @@ aktualisiert werden, in die dieses Objekt eingebettet war.
 
 ### Depublizierung von Objekten
 
-Da es sich bei OParl um eine Schnittstelle für öffentliche Daten handelt sind
-Objekte, die der Öffentlichkeit entzogen - also depubliziert - werden im Sinne
-der Schnittstelle als gelöscht zu betrachten und **sollten** wie oben behandelt
-werden.
+Da es sich bei OParl um eine Schnittstelle für öffentliche Daten handelt werden
+depublizierte Objekte im Sinne der Schnittstelle gelöscht und **sollen** wie oben
+behandelt werden.

--- a/src/2-08-geloeschte-objekte.md
+++ b/src/2-08-geloeschte-objekte.md
@@ -1,14 +1,14 @@
 ## Gelöschte Objekte {#geloeschte-objekte}
 
-In OParl **dürfen** Objekte **nicht** einfach gelöscht werden, sodass unter 
-der betreffenden URL kein gültiges Objekt ausgeliefert wird. Stattdessen 
+In OParl **dürfen** Objekte **nicht** einfach gelöscht werden, sodass unter
+der betreffenden URL kein gültiges Objekt ausgeliefert wird. Stattdessen
  wird ein sogenanntes _soft delete_ verwendet.
 
 Hintergrund ist, dass OParl-Clients bei der Aktualisierung ihres
- Datenbestandes, z.B. mit den [Filtern](#filter) `modified_since` bzw. 
+ Datenbestandes, z.B. mit den [Filtern](#filter) `modified_since` bzw.
  `created_since`, erfahren können müssen, welche Objekte gelöscht wurden.
 
-Dies wird durch die folgenden Regeln gewährleistet. 
+Dies wird durch die folgenden Regeln gewährleistet.
 
 Wenn ein Objekt gelöscht wird,
 
@@ -24,3 +24,10 @@ Neu in OParl 1.1: Die Objekte _LegislativeTerm_, _Membership_, _AgendaItem_ und
 _Consultation_ dürfen nicht mehr einfach gelöscht werden. Um Kompatibilität zu
 OParl 1.0 zu gewährleisten muss weiterhin der Wert `modified` aller Objekte
 aktualisiert werden, in die dieses Objekt eingebettet war.
+
+### Depublizierung von Objekten
+
+Da es sich bei OParl um eine Schnittstelle für öffentliche Daten handelt sind
+Objekte, die der Öffentlichkeit entzogen - also depubliziert - werden im Sinne
+der Schnittstelle als gelöscht zu betrachten und **sollten** wie oben behandelt
+werden.


### PR DESCRIPTION
Das Depublizieren von Objekten ist ein bisher nur implizit behandelter Fall der Löschung und soll hiermit konkretisiert werden.